### PR TITLE
chore(cors): configuração global de CORS para liberação de requisições do frontend

### DIFF
--- a/backend/src/main/java/com/api/app/config/CorsConfig.java
+++ b/backend/src/main/java/com/api/app/config/CorsConfig.java
@@ -1,0 +1,26 @@
+package com.api.app.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("http://localhost:5173")); // frontend Vite
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}


### PR DESCRIPTION
Configuração de CORS (Cross-Origin Resource Sharing)

- Criado CorsConfig para permitir requisições do frontend.
- Habilitado CORS global com métodos e headers comuns (GET, POST, etc.).
- Configuração essencial para integração segura entre frontend e backend.